### PR TITLE
Updates for CoffeeScript 1.5

### DIFF
--- a/examples/test/acceptance/config.coffee
+++ b/examples/test/acceptance/config.coffee
@@ -1,6 +1,6 @@
 config.credentials =
-  'username':             'mnshah'
-  'access-key':           '7d9b57de-5776-4ca6-8ba3-69bd7e37ae25'
+  'username':             'sauce_labs_username'
+  'access-key':           'sauce_labs_access_key'
   
 config.settings =
   'max-duration':         '180'

--- a/examples/test/acceptance/config.coffee
+++ b/examples/test/acceptance/config.coffee
@@ -1,6 +1,6 @@
 config.credentials =
-  'username':             'sauce_labs_username'
-  'access-key':           'sauce_labs_access_key'
+  'username':             'mnshah'
+  'access-key':           '7d9b57de-5776-4ca6-8ba3-69bd7e37ae25'
   
 config.settings =
   'max-duration':         '180'

--- a/lib/acceptance.coffee
+++ b/lib/acceptance.coffee
@@ -6,7 +6,6 @@ BASE_DIR        = 'test/acceptance'
 stories         = []
 selectedStories = []
 global.config   = {browsers: []}
-global.steps = {}
 
 
 ###
@@ -259,7 +258,7 @@ getStoriesSync = ->
 Loads the set of step files.
 ###
 loadStepsSync = -> 
-  steps = {}
+  global.steps = {}
   # Each step file adds one or more a functions as properties to this object.
   fsUtil.evaluateFilesSync BASE_DIR, 'steps.coffee'
 
@@ -268,7 +267,6 @@ loadStepsSync = ->
 Loads the configuration file.
 ###
 loadConfigSync = (browser=null)-> 
-  config = {}
   fsUtil.evaluateFilesSync BASE_DIR, 'config.coffee'
   
   if browser? then config.browsers = [config.browsers[browser - 1]]

--- a/lib/acceptance.coffee
+++ b/lib/acceptance.coffee
@@ -5,7 +5,9 @@ driver    = require './driver'
 BASE_DIR        = 'test/acceptance'
 stories         = []
 selectedStories = []
-global.config   = browsers: []
+global.config   = {browsers: []}
+global.steps = {}
+
 
 ###
 Module: Given/When/Then acceptance test semantics wrapper around Sauce Labs Selenium testing.
@@ -61,6 +63,7 @@ module.exports =
       color.blue
 
     # Enumerate each story, executing the scenarios against each configuration.
+
     for story in stories
       for scenario in story.scenarios  
         for browserConfig in config.browsers
@@ -71,13 +74,13 @@ module.exports =
             credentials, settings, browserConfig, options.subtitles
           
           do (title, browser, browserConfig) ->
-            
             # Invoke the scenario with the prepared browser client.
             scenario(browser)
             
             # Set up the callback for the scenario (also kicks it off).
             browser.end (err) ->
               browser.quit (quitErr) ->
+
                 err ?= quitErr
                 
                 browser.setSauceSuccess !err?, (sauceSuccessErr) ->
@@ -89,7 +92,6 @@ module.exports =
                     errors.push err
               
                   log.append '.', if err? then color.red else color.green
-              
                   # Check for completion and, if complete, report success or errors.
                   onComplete()
 
@@ -257,8 +259,8 @@ getStoriesSync = ->
 Loads the set of step files.
 ###
 loadStepsSync = -> 
+  steps = {}
   # Each step file adds one or more a functions as properties to this object.
-  steps ?= {}
   fsUtil.evaluateFilesSync BASE_DIR, 'steps.coffee'
 
 
@@ -266,7 +268,7 @@ loadStepsSync = ->
 Loads the configuration file.
 ###
 loadConfigSync = (browser=null)-> 
-  config ?= {}
+  config = {}
   fsUtil.evaluateFilesSync BASE_DIR, 'config.coffee'
   
   if browser? then config.browsers = [config.browsers[browser - 1]]

--- a/lib/driver.coffee
+++ b/lib/driver.coffee
@@ -328,6 +328,37 @@ module.exports =
       
         callback? err, data
 
+    ###
+    RemoteWebDriver: Elements.
+    @see:
+      http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/element.
+    @param value:     Elements to search for.
+    @param callback:  Callback.
+    @options using:   Locator strategy to use. Defaults to 'id'.
+    @returns: Selenium WebElement ID or null if element not found.
+    ###    
+    _driver_elements: (value, opts={}, callback) ->
+      opts.using ?= 'id'
+      url = @_getSauceDriverUrl 'elements'
+    
+      data = JSON.stringify {
+        using: opts.using
+        value: value
+      }
+      
+      @_callService url, 'post', data, (err, data, response) ->
+        # TODO: Check general error handling. 
+        # Am I doing it right, or should we be doing more throwing and catching instead
+        # of passing.
+        
+        # If we get a 500, that means the element wasn't found.
+        if err? && response.statusCode is 500
+          err = data = null
+        else 
+          data = data.value.ELEMENT
+      
+        callback? err, data
+
 
     ###
     Wrapper for RemoteWebDriver element/click that takes a locator strategy and search value.

--- a/lib/fs.coffee
+++ b/lib/fs.coffee
@@ -25,7 +25,7 @@ module.exports =
           js = CoffeeScript.compile(data)
         catch error
           throw "Failed to compile coffee-script in acceptance test file: " +
-            "\n[#{p}].\n#{error}\n"
+            "\n[#{path}].\n#{error}\n"
 
         # Execute the javascript.
         global.eval js


### PR DESCRIPTION
I was able to successfully run cake test:acceptance within the examples directory on Sauce with the config also in the examples directory.

The main issue seemed to be that the steps object and the config object were not available in the global context when coffeescript went to eval other coffee files to append to the steps and config objects.
